### PR TITLE
Add generalization to support OrchardZSA and AssetBase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Add target
         run: rustup target add ${{ matrix.target }}
       - name: Build crate
-        run: cargo build --no-default-features --verbose --target ${{ matrix.target }}
+        run: cargo build --features=alloc --no-default-features --verbose --target ${{ matrix.target }}
 
   bitrot:
     name: Bitrot check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.61.0"
 categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.65.0"
 categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.61.0"
 categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.65.0"
 components = [ "clippy", "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.1"
-components = ["clippy", "rustfmt"]
+channel = "1.61.0"
+components = [ "clippy", "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.61.0"
 components = [ "clippy", "rustfmt" ]

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec; // module is alloc only
 
 use crate::{
     try_compact_note_decryption_inner, try_note_decryption_inner, BatchDomain, EphemeralKeyBytes,
-    ShieldedOutput, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
+    ShieldedOutput,
 };
 
 /// Trial decryption of a batch of notes with a set of recipients.
@@ -16,7 +16,7 @@ use crate::{
 /// provided, along with the index in the `ivks` slice associated with
 /// the IVK that successfully decrypted the output.
 #[allow(clippy::type_complexity)]
-pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
 ) -> Vec<Option<((D::Note, D::Recipient, D::Memo), usize)>> {
@@ -32,14 +32,14 @@ pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERT
 /// provided, along with the index in the `ivks` slice associated with
 /// the IVK that successfully decrypted the output.
 #[allow(clippy::type_complexity)]
-pub fn try_compact_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>>(
+pub fn try_compact_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
 ) -> Vec<Option<((D::Note, D::Recipient), usize)>> {
     batch_note_decryption(ivks, outputs, try_compact_note_decryption_inner)
 }
 
-fn batch_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, CS>, F, FR, const CS: usize>(
+fn batch_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>, F, FR>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
     decrypt_inner: F,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,10 @@
 #![deny(unsafe_code)]
 // TODO: #![deny(missing_docs)]
 
-use core::fmt::{self, Write};
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use alloc::{borrow::ToOwned, vec::Vec};
 
 use chacha20::{
     cipher::{StreamCipher, StreamCipherSeek},
@@ -40,19 +38,14 @@ use subtle::{Choice, ConstantTimeEq};
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod batch;
 
-/// The size of a compact note.
-pub const COMPACT_NOTE_SIZE: usize = 1 + // version
-    11 + // diversifier
-    8  + // value
-    32; // rseed (or rcm prior to ZIP 212)
-/// The size of [`NotePlaintextBytes`].
-pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
+/// The size of the memo.
+pub const MEMO_SIZE: usize = 512;
+/// The size of the authentication tag used for note encryption.
+pub const AEAD_TAG_SIZE: usize = 16;
+
 /// The size of [`OutPlaintextBytes`].
 pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
     32; // esk
-const AEAD_TAG_SIZE: usize = 16;
-/// The size of an encrypted note plaintext.
-pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 /// The size of an encrypted outgoing plaintext.
 pub const OUT_CIPHERTEXT_SIZE: usize = OUT_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 
@@ -74,27 +67,8 @@ impl AsRef<[u8]> for OutgoingCipherKey {
 /// Newtype representing the byte encoding of an [`EphemeralPublicKey`].
 ///
 /// [`EphemeralPublicKey`]: Domain::EphemeralPublicKey
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EphemeralKeyBytes(pub [u8; 32]);
-
-impl fmt::Debug for EphemeralKeyBytes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        struct HexFmt<'b>(&'b [u8]);
-        impl<'b> fmt::Debug for HexFmt<'b> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_char('"')?;
-                for b in self.0 {
-                    f.write_fmt(format_args!("{:02x}", b))?;
-                }
-                f.write_char('"')
-            }
-        }
-
-        f.debug_tuple("EphemeralKeyBytes")
-            .field(&HexFmt(&self.0))
-            .finish()
-    }
-}
 
 impl AsRef<[u8]> for EphemeralKeyBytes {
     fn as_ref(&self) -> &[u8] {
@@ -114,8 +88,6 @@ impl ConstantTimeEq for EphemeralKeyBytes {
     }
 }
 
-/// Newtype representing the byte encoding of a note plaintext.
-pub struct NotePlaintextBytes(pub [u8; NOTE_PLAINTEXT_SIZE]);
 /// Newtype representing the byte encoding of a outgoing plaintext.
 pub struct OutPlaintextBytes(pub [u8; OUT_PLAINTEXT_SIZE]);
 
@@ -144,6 +116,11 @@ pub trait Domain {
     type ExtractedCommitment;
     type ExtractedCommitmentBytes: Eq + for<'a> From<&'a Self::ExtractedCommitment>;
     type Memo;
+
+    type NotePlaintextBytes: AsMut<[u8]> + for<'a> From<&'a [u8]>;
+    type NoteCiphertextBytes: AsRef<[u8]> + for<'a> From<&'a [u8]>;
+    type CompactNotePlaintextBytes: AsMut<[u8]> + for<'a> From<&'a [u8]>;
+    type CompactNoteCiphertextBytes: AsRef<[u8]>;
 
     /// Derives the `EphemeralSecretKey` corresponding to this note.
     ///
@@ -192,7 +169,7 @@ pub trait Domain {
     fn kdf(secret: Self::SharedSecret, ephemeral_key: &EphemeralKeyBytes) -> Self::SymmetricKey;
 
     /// Encodes the given `Note` and `Memo` as a note plaintext.
-    fn note_plaintext_bytes(note: &Self::Note, memo: &Self::Memo) -> NotePlaintextBytes;
+    fn note_plaintext_bytes(note: &Self::Note, memo: &Self::Memo) -> Self::NotePlaintextBytes;
 
     /// Derives the [`OutgoingCipherKey`] for an encrypted note, given the note-specific
     /// public data and an `OutgoingViewingKey`.
@@ -233,14 +210,10 @@ pub trait Domain {
     /// such as rules like [ZIP 212] that become active at a specific block height.
     ///
     /// [ZIP 212]: https://zips.z.cash/zip-0212
-    ///
-    /// # Panics
-    ///
-    /// Panics if `plaintext` is shorter than [`COMPACT_NOTE_SIZE`].
     fn parse_note_plaintext_without_memo_ivk(
         &self,
         ivk: &Self::IncomingViewingKey,
-        plaintext: &[u8],
+        plaintext: &Self::CompactNotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)>;
 
     /// Parses the given note plaintext from the sender's perspective.
@@ -258,16 +231,19 @@ pub trait Domain {
     fn parse_note_plaintext_without_memo_ovk(
         &self,
         pk_d: &Self::DiversifiedTransmissionKey,
-        plaintext: &NotePlaintextBytes,
+        plaintext: &Self::CompactNotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)>;
 
-    /// Extracts the memo field from the given note plaintext.
+    /// Splits the memo field from the given note plaintext.
     ///
     /// # Compatibility
     ///
     /// `&self` is passed here in anticipation of future changes to memo handling, where
     /// the memos may no longer be part of the note plaintext.
-    fn extract_memo(&self, plaintext: &NotePlaintextBytes) -> Self::Memo;
+    fn extract_memo(
+        &self,
+        plaintext: &Self::NotePlaintextBytes,
+    ) -> (Self::CompactNotePlaintextBytes, Self::Memo);
 
     /// Parses the `DiversifiedTransmissionKey` field of the outgoing plaintext.
     ///
@@ -326,19 +302,18 @@ pub trait BatchDomain: Domain {
 }
 
 /// Trait that provides access to the components of an encrypted transaction output.
-///
-/// Implementations of this trait are required to define the length of their ciphertext
-/// field. In order to use the trial decryption APIs in this crate, the length must be
-/// either [`ENC_CIPHERTEXT_SIZE`] or [`COMPACT_NOTE_SIZE`].
-pub trait ShieldedOutput<D: Domain, const CIPHERTEXT_SIZE: usize> {
+pub trait ShieldedOutput<D: Domain> {
     /// Exposes the `ephemeral_key` field of the output.
     fn ephemeral_key(&self) -> EphemeralKeyBytes;
 
     /// Exposes the `cmu_bytes` or `cmx_bytes` field of the output.
     fn cmstar_bytes(&self) -> D::ExtractedCommitmentBytes;
 
-    /// Exposes the note ciphertext of the output.
-    fn enc_ciphertext(&self) -> &[u8; CIPHERTEXT_SIZE];
+    /// Exposes the note ciphertext of the output. Returns `None` if the output is compact.
+    fn enc_ciphertext(&self) -> Option<D::NoteCiphertextBytes>;
+
+    /// Exposes the compact note ciphertext of the output.
+    fn enc_ciphertext_compact(&self) -> D::CompactNoteCiphertextBytes;
 }
 
 /// A struct containing context required for encrypting Sapling and Orchard notes.
@@ -403,24 +378,18 @@ impl<D: Domain> NoteEncryption<D> {
     }
 
     /// Generates `encCiphertext` for this note.
-    pub fn encrypt_note_plaintext(&self) -> [u8; ENC_CIPHERTEXT_SIZE] {
+    pub fn encrypt_note_plaintext(&self) -> D::NoteCiphertextBytes {
         let pk_d = D::get_pk_d(&self.note);
         let shared_secret = D::ka_agree_enc(&self.esk, &pk_d);
         let key = D::kdf(shared_secret, &D::epk_bytes(&self.epk));
-        let input = D::note_plaintext_bytes(&self.note, &self.memo);
+        let mut input = D::note_plaintext_bytes(&self.note, &self.memo);
 
-        let mut output = [0u8; ENC_CIPHERTEXT_SIZE];
-        output[..NOTE_PLAINTEXT_SIZE].copy_from_slice(&input.0);
+        let output = input.as_mut();
+
         let tag = ChaCha20Poly1305::new(key.as_ref().into())
-            .encrypt_in_place_detached(
-                [0u8; 12][..].into(),
-                &[],
-                &mut output[..NOTE_PLAINTEXT_SIZE],
-            )
+            .encrypt_in_place_detached([0u8; 12][..].into(), &[], output)
             .unwrap();
-        output[NOTE_PLAINTEXT_SIZE..].copy_from_slice(&tag);
-
-        output
+        D::NoteCiphertextBytes::from(&[output, tag.as_ref()].concat())
     }
 
     /// Generates `outCiphertext` for this note.
@@ -465,7 +434,7 @@ impl<D: Domain> NoteEncryption<D> {
 ///
 /// Implements section 4.19.2 of the
 /// [Zcash Protocol Specification](https://zips.z.cash/protocol/nu5.pdf#decryptivk).
-pub fn try_note_decryption<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+pub fn try_note_decryption<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     output: &Output,
@@ -479,35 +448,29 @@ pub fn try_note_decryption<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_S
     try_note_decryption_inner(domain, ivk, &ephemeral_key, output, &key)
 }
 
-fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     ephemeral_key: &EphemeralKeyBytes,
     output: &Output,
     key: &D::SymmetricKey,
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
-    let enc_ciphertext = output.enc_ciphertext();
+    let mut enc_ciphertext = output.enc_ciphertext()?.as_ref().to_owned();
 
-    let mut plaintext =
-        NotePlaintextBytes(enc_ciphertext[..NOTE_PLAINTEXT_SIZE].try_into().unwrap());
+    let (plaintext, tag) = extract_tag(&mut enc_ciphertext);
 
     ChaCha20Poly1305::new(key.as_ref().into())
-        .decrypt_in_place_detached(
-            [0u8; 12][..].into(),
-            &[],
-            &mut plaintext.0,
-            enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-        )
+        .decrypt_in_place_detached([0u8; 12][..].into(), &[], plaintext, &tag.into())
         .ok()?;
 
+    let (compact, memo) = domain.extract_memo(&D::NotePlaintextBytes::from(plaintext));
     let (note, to) = parse_note_plaintext_without_memo_ivk(
         domain,
         ivk,
         ephemeral_key,
         &output.cmstar_bytes(),
-        &plaintext.0,
+        &compact,
     )?;
-    let memo = domain.extract_memo(&plaintext);
 
     Some((note, to, memo))
 }
@@ -517,7 +480,7 @@ fn parse_note_plaintext_without_memo_ivk<D: Domain>(
     ivk: &D::IncomingViewingKey,
     ephemeral_key: &EphemeralKeyBytes,
     cmstar_bytes: &D::ExtractedCommitmentBytes,
-    plaintext: &[u8],
+    plaintext: &D::CompactNotePlaintextBytes,
 ) -> Option<(D::Note, D::Recipient)> {
     let (note, to) = domain.parse_note_plaintext_without_memo_ivk(ivk, plaintext)?;
 
@@ -564,7 +527,7 @@ fn check_note_validity<D: Domain>(
 /// Implements the procedure specified in [`ZIP 307`].
 ///
 /// [`ZIP 307`]: https://zips.z.cash/zip-0307
-pub fn try_compact_note_decryption<D: Domain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>>(
+pub fn try_compact_note_decryption<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     output: &Output,
@@ -578,7 +541,7 @@ pub fn try_compact_note_decryption<D: Domain, Output: ShieldedOutput<D, COMPACT_
     try_compact_note_decryption_inner(domain, ivk, &ephemeral_key, output, &key)
 }
 
-fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>>(
+fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     ephemeral_key: &EphemeralKeyBytes,
@@ -586,11 +549,12 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D, COMPAC
     key: &D::SymmetricKey,
 ) -> Option<(D::Note, D::Recipient)> {
     // Start from block 1 to skip over Poly1305 keying output
-    let mut plaintext = [0; COMPACT_NOTE_SIZE];
-    plaintext.copy_from_slice(output.enc_ciphertext());
+    let mut plaintext: D::CompactNotePlaintextBytes =
+        output.enc_ciphertext_compact().as_ref().into();
+
     let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
     keystream.seek(64);
-    keystream.apply_keystream(&mut plaintext);
+    keystream.apply_keystream(plaintext.as_mut());
 
     parse_note_plaintext_without_memo_ivk(
         domain,
@@ -610,7 +574,7 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D, COMPAC
 /// Implements [Zcash Protocol Specification section 4.19.3][decryptovk].
 ///
 /// [decryptovk]: https://zips.z.cash/protocol/nu5.pdf#decryptovk
-pub fn try_output_recovery_with_ovk<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+pub fn try_output_recovery_with_ovk<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ovk: &D::OutgoingViewingKey,
     output: &Output,
@@ -630,14 +594,12 @@ pub fn try_output_recovery_with_ovk<D: Domain, Output: ShieldedOutput<D, ENC_CIP
 /// Implements part of section 4.19.3 of the
 /// [Zcash Protocol Specification](https://zips.z.cash/protocol/nu5.pdf#decryptovk).
 /// For decryption using a Full Viewing Key see [`try_output_recovery_with_ovk`].
-pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ock: &OutgoingCipherKey,
     output: &Output,
     out_ciphertext: &[u8; OUT_CIPHERTEXT_SIZE],
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
-    let enc_ciphertext = output.enc_ciphertext();
-
     let mut op = OutPlaintextBytes([0; OUT_PLAINTEXT_SIZE]);
     op.0.copy_from_slice(&out_ciphertext[..OUT_PLAINTEXT_SIZE]);
 
@@ -660,22 +622,17 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIP
     // be okay.
     let key = D::kdf(shared_secret, &ephemeral_key);
 
-    let mut plaintext = NotePlaintextBytes([0; NOTE_PLAINTEXT_SIZE]);
-    plaintext
-        .0
-        .copy_from_slice(&enc_ciphertext[..NOTE_PLAINTEXT_SIZE]);
+    let mut enc_ciphertext = output.enc_ciphertext()?.as_ref().to_owned();
+
+    let (plaintext, tag) = extract_tag(&mut enc_ciphertext);
 
     ChaCha20Poly1305::new(key.as_ref().into())
-        .decrypt_in_place_detached(
-            [0u8; 12][..].into(),
-            &[],
-            &mut plaintext.0,
-            enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-        )
+        .decrypt_in_place_detached([0u8; 12][..].into(), &[], plaintext, &tag.into())
         .ok()?;
 
-    let (note, to) = domain.parse_note_plaintext_without_memo_ovk(&pk_d, &plaintext)?;
-    let memo = domain.extract_memo(&plaintext);
+    let (compact, memo) = domain.extract_memo(&plaintext.as_ref().into());
+
+    let (note, to) = domain.parse_note_plaintext_without_memo_ovk(&pk_d, &compact)?;
 
     // ZIP 212: Check that the esk provided to this function is consistent with the esk we can
     // derive from the note. This check corresponds to `ToScalar(PRF^{expand}_{rseed}([4]) = esk`
@@ -693,4 +650,14 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIP
     } else {
         None
     }
+}
+
+// Splits the AEAD tag from the ciphertext.
+fn extract_tag(enc_ciphertext: &mut Vec<u8>) -> (&mut [u8], [u8; AEAD_TAG_SIZE]) {
+    let tag_loc = enc_ciphertext.len() - AEAD_TAG_SIZE;
+
+    let (plaintext, tail) = enc_ciphertext.split_at_mut(tag_loc);
+
+    let tag: [u8; AEAD_TAG_SIZE] = tail.try_into().unwrap();
+    (plaintext, tag)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 #![deny(unsafe_code)]
 // TODO: #![deny(missing_docs)]
 
+use core::fmt::{self, Write};
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "alloc")]
@@ -67,8 +69,27 @@ impl AsRef<[u8]> for OutgoingCipherKey {
 /// Newtype representing the byte encoding of an [`EphemeralPublicKey`].
 ///
 /// [`EphemeralPublicKey`]: Domain::EphemeralPublicKey
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct EphemeralKeyBytes(pub [u8; 32]);
+
+impl fmt::Debug for EphemeralKeyBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct HexFmt<'b>(&'b [u8]);
+        impl<'b> fmt::Debug for HexFmt<'b> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_char('"')?;
+                for b in self.0 {
+                    f.write_fmt(format_args!("{:02x}", b))?;
+                }
+                f.write_char('"')
+            }
+        }
+
+        f.debug_tuple("EphemeralKeyBytes")
+            .field(&HexFmt(&self.0))
+            .finish()
+    }
+}
 
 impl AsRef<[u8]> for EphemeralKeyBytes {
     fn as_ref(&self) -> &[u8] {


### PR DESCRIPTION
This PR updates the `zsa1` branch to integrate our modifications of `zcash_note_encryption` crate made in the `zsa1` branch of the `librustzcash` repository. The Zcash team recently organized the `zcash_note_encryption` crate into a standalone repository, so we align our codebase with this structural change.

The only change in this PR is the inclusion of the updated `src` folder from the `zcash_note_encryption` crate of our fork of the `librustzcash` repository: https://github.com/QED-it/librustzcash/tree/zsa1/components/zcash_note_encryption