### PR TITLE
Avoid use of Vec in ZSA-compatible version of lib.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Add target
         run: rustup target add ${{ matrix.target }}
       - name: Build crate
-        run: cargo build --features=alloc --no-default-features --verbose --target ${{ matrix.target }}
+        run: cargo build --no-default-features --verbose --target ${{ matrix.target }}
 
   bitrot:
     name: Bitrot check


### PR DESCRIPTION
## Problem

The current CI build for this `zcash_note_encryption` crate is failing when attempting to merge ZSA-related changes made in `lib.rs`. This issue arises from the use of `Vec` generic defined in the standard library ("std"), while the crate is configured with the `#![no_std]` directive in `lib.rs`.

## Current solution

To address the CI build failure, a temporary solution has been implemented by modifying the GitHub Actions CI configuration (`ci.yml`) to enable the "alloc" feature. Since "alloc" also contains the definition of `Vec` and can serve as a lightweight alternative to "std," this adjustment allows the CI to complete successfully.

`ci.yml`:
```yaml
...
        run: cargo build --features=alloc --no-default-features --verbose --target ${{ matrix.target }}
...
```

While this approach resolves the immediate CI issue, it introduces additional dependencies. This may not be optimal, especially for scenarios involving the usage of `zcash_note_encryption` in embedded solutions or on the browser side.

### Proposed slternative solution

An alternative solution is presented in this draft pull request, involving modifications to the `lib.rs` file to eliminate the use of `Vec`. It's important to note that this alternative solution requires corresponding adjustments in the `orchard_zsa` crate, which implements the `Domain` trait from `zcash_note_encryption`.