### PR TITLE
Revert MSRV to 1.56.1 with minor code adjustments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/zcash/librustzcash"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.56.1"
 categories = ["cryptography::cryptocurrencies"]
 
 [package.metadata.docs.rs]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.56.1"
 components = [ "clippy", "rustfmt" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,6 +681,6 @@ fn extract_tag(enc_ciphertext: &mut [u8]) -> (&mut [u8], [u8; AEAD_TAG_SIZE]) {
 
     let (plaintext, tail) = enc_ciphertext.split_at_mut(tag_loc);
 
-    let tag: [u8; AEAD_TAG_SIZE] = tail.try_into().unwrap();
+    let tag: [u8; AEAD_TAG_SIZE] = tail.as_ref().try_into().unwrap();
     (plaintext, tag)
 }


### PR DESCRIPTION
This pull request reverts the Minimum Supported Rust Version (MSRV) for the `zcash_note_encryption` crate from 1.61.1 back to 1.56.1.

A minor code adjustment was made using `as_ref` to convert a mutable reference to an immutable reference, as older Rust versions do not support `TryFrom` for mutable references.
