### PR TITLE
Update CHANGELOG.md with changes for note plaintext size generalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Generalized note plaintext size to support variable note sizes, including
+  AssetId for ZSA notes. Moved constants into `Domain` trait implementations
+  (e.g., `OrchardDomain`, `Sapling`).
+- Added abstract types `NotePlaintextBytes`, `NoteCiphertextBytes`,
+  `CompactNotePlaintextBytes`, and `CompactNoteCiphertextBytes` to `Domain`
+  trait.
+- Updated function signatures to remove constants that are unknown at
+  compilation time.
 
 ## [0.4.0] - 2023-06-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Changed
-- Generalized note plaintext size to support variable note sizes, including
-  AssetId for ZSA notes. Moved constants into `Domain` trait implementations
-  (e.g., `OrchardDomain`, `Sapling`).
-- Added abstract types `NotePlaintextBytes`, `NoteCiphertextBytes`,
-  `CompactNotePlaintextBytes`, and `CompactNoteCiphertextBytes` to `Domain`
+- Generalized the note plaintext size to support variable sizes by adding the
+  abstract types `NotePlaintextBytes`, `NoteCiphertextBytes`,
+  `CompactNotePlaintextBytes`, and `CompactNoteCiphertextBytes` to the `Domain`
   trait.
-- Updated function signatures to remove constants that are unknown at
-  compilation time.
+- Moved the specific constants into the `Domain` trait implementations.
 
 ## [0.4.0] - 2023-06-06
 ### Changed


### PR DESCRIPTION
This PR updates the `CHANGELOG.md` to include the changes related to the note plaintext size generalization under the "Unreleased" section.