### PR TITLE
Return constants that are still in use in Sapling domain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub const COMPACT_NOTE_SIZE: usize = 1 + // version
     11 + // diversifier
     8  + // value
     32; // rseed (or rcm prior to ZIP 212)
-/// The size of [`NotePlaintextBytes`].
+/// The size of NotePlaintextBytes.
 pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
 /// The size of an encrypted note plaintext.
 pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,16 @@ pub const MEMO_SIZE: usize = 512;
 /// The size of the authentication tag used for note encryption.
 pub const AEAD_TAG_SIZE: usize = 16;
 
+/// The size of a compact note.
+pub const COMPACT_NOTE_SIZE: usize = 1 + // version
+    11 + // diversifier
+    8  + // value
+    32; // rseed (or rcm prior to ZIP 212)
+/// The size of [`NotePlaintextBytes`].
+pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
+/// The size of an encrypted note plaintext.
+pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
+
 /// The size of [`OutPlaintextBytes`].
 pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
     32; // esk


### PR DESCRIPTION
Specific values for Orchard/ZSA have been moved to respective Domains, but these are still being used by Sapling