### PR TITLE
NoteBytes moved to zcash_note_encryption

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ use subtle::{Choice, ConstantTimeEq};
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod batch;
+pub mod note_bytes;
 
 /// The size of the memo.
 pub const MEMO_SIZE: usize = 512;

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -1,0 +1,43 @@
+/// Represents a fixed-size array of bytes for note components.
+#[derive(Clone, Copy, Debug)]
+pub struct NoteBytes<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> AsRef<[u8]> for NoteBytes<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const N: usize> AsMut<[u8]> for NoteBytes<N> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+// FIXME: consider implementing and using TryFrom instead
+impl<const N: usize> From<&[u8]> for NoteBytes<N> {
+    fn from(s: &[u8]) -> Self {
+        Self(s.try_into().unwrap())
+    }
+}
+
+impl<const N: usize> From<(&[u8], &[u8])> for NoteBytes<N> {
+    fn from(s: (&[u8], &[u8])) -> Self {
+        Self([s.0, s.1].concat().try_into().unwrap())
+    }
+}
+
+/// Defines the ability to concatenate two byte slices.
+pub trait NoteByteConcat: for<'a> From<(&'a [u8], &'a [u8])> {}
+
+impl<const N: usize> NoteByteConcat for NoteBytes<N> {}
+
+/// Defines the behavior for types that can provide read-only access to their internal byte array.
+pub trait NoteByteReader: AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Copy {}
+
+impl<const N: usize> NoteByteReader for NoteBytes<N> {}
+
+/// Defines the behavior for types that support both read and write access to their internal byte array.
+pub trait NoteByteWriter: NoteByteReader + AsMut<[u8]> {}
+
+impl<const N: usize> NoteByteWriter for NoteBytes<N> {}

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -1,46 +1,59 @@
 /// Represents a fixed-size array of bytes for note components.
 #[derive(Clone, Copy, Debug)]
-pub struct NoteBytes<const N: usize>(pub [u8; N]);
+pub struct NoteBytesData<const N: usize>(pub [u8; N]);
 
-impl<const N: usize> AsRef<[u8]> for NoteBytes<N> {
+impl<const N: usize> AsRef<[u8]> for NoteBytesData<N> {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl<const N: usize> AsMut<[u8]> for NoteBytes<N> {
+impl<const N: usize> AsMut<[u8]> for NoteBytesData<N> {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
     }
 }
 
-// FIXME: consider implementing and using TryFrom instead
-impl<const N: usize> From<&[u8]> for NoteBytes<N> {
+impl<const N: usize> From<&[u8]> for NoteBytesData<N> {
     fn from(s: &[u8]) -> Self {
         Self(s.try_into().unwrap())
     }
 }
 
-impl<const N: usize> From<(&[u8], &[u8])> for NoteBytes<N> {
+impl<const N: usize> From<(&[u8], &[u8])> for NoteBytesData<N> {
     fn from(s: (&[u8], &[u8])) -> Self {
         let mut result: [u8; N] = [0; N];
         result[..s.0.len()].copy_from_slice(s.0);
         result[s.0.len()..].copy_from_slice(s.1);
-        NoteBytes::from(result.as_ref())
+        NoteBytesData::from(result.as_ref())
     }
 }
 
 /// Defines the ability to concatenate two byte slices.
 pub trait NoteByteConcat: for<'a> From<(&'a [u8], &'a [u8])> {}
 
-impl<const N: usize> NoteByteConcat for NoteBytes<N> {}
+impl<const N: usize> NoteByteConcat for NoteBytesData<N> {}
 
 /// Defines the behavior for types that can provide read-only access to their internal byte array.
 pub trait NoteByteReader: AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Copy {}
 
-impl<const N: usize> NoteByteReader for NoteBytes<N> {}
+impl<const N: usize> NoteByteReader for NoteBytesData<N> {}
 
 /// Defines the behavior for types that support both read and write access to their internal byte array.
 pub trait NoteByteWriter: NoteByteReader + AsMut<[u8]> {}
 
-impl<const N: usize> NoteByteWriter for NoteBytes<N> {}
+impl<const N: usize> NoteByteWriter for NoteBytesData<N> {}
+
+/// Provides a unified interface for handling fixed-size byte arrays used in Orchard note encryption.
+pub trait NoteBytes:
+    AsRef<[u8]>
+    + AsMut<[u8]>
+    + for<'a> From<&'a [u8]>
+    + for<'a> From<(&'a [u8], &'a [u8])>
+    + Clone
+    + Copy
+    + Send
+{
+}
+
+impl<const N: usize> NoteBytes for NoteBytesData<N> {}

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -24,7 +24,7 @@ impl<const N: usize> From<&[u8]> for NoteBytes<N> {
 impl<const N: usize> From<(&[u8], &[u8])> for NoteBytes<N> {
     fn from(s: (&[u8], &[u8])) -> Self {
         let mut result: [u8; N]  = [0; N];
-        result.copy_from_slice(s.0);
+        result[..s.0.len()].copy_from_slice(s.0);
         result[s.0.len()..].copy_from_slice(s.1);
         NoteBytes::from(result.as_ref())
     }

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -54,6 +54,13 @@ pub trait NoteBytes:
     + Copy
     + Send
 {
+    /// Constructs a new NoteBytesData from an empty slice of bytes.
+    fn new() -> Self;
 }
 
-impl<const N: usize> NoteBytes for NoteBytesData<N> {}
+impl<const N: usize> NoteBytes for NoteBytesData<N> {
+    /// Constructs a new NoteBytesData from an empty slice of bytes.
+    fn new() -> Self {
+        Self([0u8; N])
+    }
+}

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -23,7 +23,10 @@ impl<const N: usize> From<&[u8]> for NoteBytes<N> {
 
 impl<const N: usize> From<(&[u8], &[u8])> for NoteBytes<N> {
     fn from(s: (&[u8], &[u8])) -> Self {
-        Self([s.0, s.1].concat().try_into().unwrap())
+        let mut result: [u8; N]  = [0; N];
+        result.copy_from_slice(s.0);
+        result[s.0.len()..].copy_from_slice(s.1);
+        NoteBytes::from(result.as_ref())
     }
 }
 

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -23,7 +23,7 @@ impl<const N: usize> From<&[u8]> for NoteBytes<N> {
 
 impl<const N: usize> From<(&[u8], &[u8])> for NoteBytes<N> {
     fn from(s: (&[u8], &[u8])) -> Self {
-        let mut result: [u8; N]  = [0; N];
+        let mut result: [u8; N] = [0; N];
         result[..s.0.len()].copy_from_slice(s.0);
         result[s.0.len()..].copy_from_slice(s.1);
         NoteBytes::from(result.as_ref())


### PR DESCRIPTION
NoteBytes moved to zcash_note_encryption.

dmidem: This PR can be closed in favor of #9 (copy of this PR but with the destination branch changed to `zcah_pr_issues` instead of `zsa1`). PR #9 has already been merged.