### PR TITLE
Implement new parse_... methods directly in the Domain trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,9 @@ pub trait Domain {
     /// Parses the given note plaintext bytes.
     ///
     /// Returns `None` if the byte slice does not represent a valid note plaintext.
-    fn parse_note_plaintext_bytes(plaintext: &[u8]) -> Option<Self::NotePlaintextBytes>;
+    fn parse_note_plaintext_bytes(plaintext: &[u8]) -> Option<Self::NotePlaintextBytes> {
+        Self::NotePlaintextBytes::from_slice(plaintext)
+    }
 
     /// Parses the given note ciphertext bytes.
     ///
@@ -306,14 +308,18 @@ pub trait Domain {
     fn parse_note_ciphertext_bytes(
         output: &[u8],
         tag: [u8; AEAD_TAG_SIZE],
-    ) -> Option<Self::NoteCiphertextBytes>;
+    ) -> Option<Self::NoteCiphertextBytes> {
+        Self::NoteCiphertextBytes::from_slice_with_tag(output, tag)
+    }
 
     /// Parses the given compact note plaintext bytes.
     ///
     /// Returns `None` if the byte slice does not represent a valid compact note plaintext.
     fn parse_compact_note_plaintext_bytes(
         plaintext: &[u8],
-    ) -> Option<Self::CompactNotePlaintextBytes>;
+    ) -> Option<Self::CompactNotePlaintextBytes> {
+        Self::CompactNotePlaintextBytes::from_slice(plaintext)
+    }
 }
 
 /// Trait that encapsulates protocol-specific batch trial decryption logic.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ use subtle::{Choice, ConstantTimeEq};
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod batch;
+pub mod note_bytes;
 
 /// The size of the memo.
 pub const MEMO_SIZE: usize = 512;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,12 @@ pub mod note_bytes;
 
 use note_bytes::NoteBytes;
 
-/// The size of a compact note.
+/// The size of a compact note for Sapling and Orchard Vanilla.
 pub const COMPACT_NOTE_SIZE: usize = 1 + // version
     11 + // diversifier
     8  + // value
     32; // rseed (or rcm prior to ZIP 212)
-/// The size of [`NotePlaintextBytes`].
+/// The size of `NotePlaintextBytes` for Sapling and Orchard Vanilla.
 pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
 
 /// The size of the memo.
@@ -63,7 +63,7 @@ pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
 /// The size of an encrypted outgoing plaintext.
 pub const OUT_CIPHERTEXT_SIZE: usize = OUT_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 
-/// The size of an encrypted note plaintext.
+/// The size of an encrypted note plaintext for Sapling and Orchard Vanilla.
 pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 
 /// A symmetric key that can be used to recover a single Sapling or Orchard output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,18 @@ use subtle::{Choice, ConstantTimeEq};
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub mod batch;
+
 pub mod note_bytes;
+
+use note_bytes::NoteBytes;
+
+/// The size of a compact note.
+pub const COMPACT_NOTE_SIZE: usize = 1 + // version
+    11 + // diversifier
+    8  + // value
+    32; // rseed (or rcm prior to ZIP 212)
+/// The size of [`NotePlaintextBytes`].
+pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
 
 /// The size of the memo.
 pub const MEMO_SIZE: usize = 512;
@@ -51,6 +62,9 @@ pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
     32; // esk
 /// The size of an encrypted outgoing plaintext.
 pub const OUT_CIPHERTEXT_SIZE: usize = OUT_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
+
+/// The size of an encrypted note plaintext.
+pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 
 /// A symmetric key that can be used to recover a single Sapling or Orchard output.
 pub struct OutgoingCipherKey(pub [u8; 32]);
@@ -139,15 +153,10 @@ pub trait Domain {
     type ExtractedCommitmentBytes: Eq + for<'a> From<&'a Self::ExtractedCommitment>;
     type Memo;
 
-    // FIXME: having four new parse_... methods of the trait cause a code duplication in
-    // the trait implementation. Now we use NoteBytes trait that constainted by all thoose ArRef,
-    // AsMut, From and NoteBytesData generic struct that implement NoteBytes for any length
-    type NotePlaintextBytes: AsMut<[u8]>;
-    // FIXME: [u8; AEAD_TAG_SIZE] instead of &[u8] doesn't give any benefit (except type/size
-    // safety) as we will need to allocalte memory for NoteCiphertextBytes anyway
-    type NoteCiphertextBytes: AsRef<[u8]>;
-    type CompactNotePlaintextBytes: AsMut<[u8]> + From<&[u8>>;//Self::CompactNoteCiphertextBytes>;
-    type CompactNoteCiphertextBytes: AsRef<[u8]>;
+    type NotePlaintextBytes: NoteBytes;
+    type NoteCiphertextBytes: NoteBytes;
+    type CompactNotePlaintextBytes: NoteBytes;
+    type CompactNoteCiphertextBytes: NoteBytes;
 
     /// Derives the `EphemeralSecretKey` corresponding to this note.
     ///
@@ -270,7 +279,7 @@ pub trait Domain {
     fn split_plaintext_at_memo(
         &self,
         plaintext: &Self::NotePlaintextBytes,
-    ) -> (Self::CompactNotePlaintextBytes, Self::Memo);
+    ) -> Option<(Self::CompactNotePlaintextBytes, Self::Memo)>;
 
     /// Parses the `DiversifiedTransmissionKey` field of the outgoing plaintext.
     ///
@@ -284,14 +293,27 @@ pub trait Domain {
     /// `EphemeralSecretKey`.
     fn extract_esk(out_plaintext: &OutPlaintextBytes) -> Option<Self::EphemeralSecretKey>;
 
-    // FIXME: add doc
+    /// Parses the given note plaintext bytes.
+    ///
+    /// Returns `None` if the byte slice does not represent a valid note plaintext.
     fn parse_note_plaintext_bytes(plaintext: &[u8]) -> Option<Self::NotePlaintextBytes>;
 
-    // FIXME: add doc
+    /// Parses the given note ciphertext bytes.
+    ///
+    /// `output` is the ciphertext bytes, and `tag` is the authentication tag.
+    ///
+    /// Returns `None` if the byte slice does not represent a valid note ciphertext.
     fn parse_note_ciphertext_bytes(
         output: &[u8],
         tag: [u8; AEAD_TAG_SIZE],
     ) -> Option<Self::NoteCiphertextBytes>;
+
+    /// Parses the given compact note plaintext bytes.
+    ///
+    /// Returns `None` if the byte slice does not represent a valid compact note plaintext.
+    fn parse_compact_note_plaintext_bytes(
+        plaintext: &[u8],
+    ) -> Option<Self::CompactNotePlaintextBytes>;
 }
 
 /// Trait that encapsulates protocol-specific batch trial decryption logic.
@@ -345,11 +367,15 @@ pub trait ShieldedOutput<D: Domain> {
     /// Exposes the `cmu_bytes` or `cmx_bytes` field of the output.
     fn cmstar_bytes(&self) -> D::ExtractedCommitmentBytes;
 
+    // FIXME: we can't return a ref to NoteCiphertextBytes as it's not a member of self or
+    // a static object in saplic-crypto crate (but it is a mamber of self in orchard crate)
+    // Should we really need to return Option here?
     /// Exposes the note ciphertext of the output. Returns `None` if the output is compact.
     fn enc_ciphertext(&self) -> Option<D::NoteCiphertextBytes>;
 
-    // FIXME: we can't return a ref to CompactNoteCiphertextBytes as it's not a member or self or
-    // a static object
+    // FIXME: we can't return a ref to CompactNoteCiphertextBytes as it's not a member of self or
+    // a static object neither in orchard nor in saplic-crypto crate
+    // FIXME: Should we return Option<...> instead?
     /// Exposes the compact note ciphertext of the output.
     fn enc_ciphertext_compact(&self) -> D::CompactNoteCiphertextBytes;
 }
@@ -499,7 +525,7 @@ fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
         .decrypt_in_place_detached([0u8; 12][..].into(), &[], plaintext.as_mut(), &tag.into())
         .ok()?;
 
-    let (compact, memo) = domain.split_plaintext_at_memo(&plaintext);
+    let (compact, memo) = domain.split_plaintext_at_memo(&plaintext)?;
     let (note, to) = parse_note_plaintext_without_memo_ivk(
         domain,
         ivk,
@@ -585,7 +611,8 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     key: &D::SymmetricKey,
 ) -> Option<(D::Note, D::Recipient)> {
     // Start from block 1 to skip over Poly1305 keying output
-    let mut plaintext: D::CompactNotePlaintextBytes = output.enc_ciphertext_compact().into();
+    let mut plaintext: D::CompactNotePlaintextBytes =
+        D::parse_compact_note_plaintext_bytes(output.enc_ciphertext_compact().as_ref())?;
 
     let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
     keystream.seek(64);
@@ -663,7 +690,7 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
         .decrypt_in_place_detached([0u8; 12][..].into(), &[], plaintext.as_mut(), &tag.into())
         .ok()?;
 
-    let (compact, memo) = domain.split_plaintext_at_memo(&plaintext);
+    let (compact, memo) = domain.split_plaintext_at_memo(&plaintext)?;
 
     let (note, to) = domain.parse_note_plaintext_without_memo_ovk(&pk_d, &compact)?;
 

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -14,53 +14,37 @@ impl<const N: usize> AsMut<[u8]> for NoteBytesData<N> {
     }
 }
 
-impl<const N: usize> From<&[u8]> for NoteBytesData<N> {
-    fn from(s: &[u8]) -> Self {
-        Self(s.try_into().unwrap())
-    }
-}
+/// Provides a unified interface for handling fixed-size byte arrays used in note encryption.
+pub trait NoteBytes: AsRef<[u8]> + AsMut<[u8]> + Clone + Copy {
+    fn from_slice(bytes: &[u8]) -> Option<Self>;
 
-impl<const N: usize> From<(&[u8], &[u8])> for NoteBytesData<N> {
-    fn from(s: (&[u8], &[u8])) -> Self {
-        let mut result: [u8; N] = [0; N];
-        result[..s.0.len()].copy_from_slice(s.0);
-        result[s.0.len()..].copy_from_slice(s.1);
-        NoteBytesData::from(result.as_ref())
-    }
-}
-
-/// Defines the ability to concatenate two byte slices.
-pub trait NoteByteConcat: for<'a> From<(&'a [u8], &'a [u8])> {}
-
-impl<const N: usize> NoteByteConcat for NoteBytesData<N> {}
-
-/// Defines the behavior for types that can provide read-only access to their internal byte array.
-pub trait NoteByteReader: AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Copy {}
-
-impl<const N: usize> NoteByteReader for NoteBytesData<N> {}
-
-/// Defines the behavior for types that support both read and write access to their internal byte array.
-pub trait NoteByteWriter: NoteByteReader + AsMut<[u8]> {}
-
-impl<const N: usize> NoteByteWriter for NoteBytesData<N> {}
-
-/// Provides a unified interface for handling fixed-size byte arrays used in Orchard note encryption.
-pub trait NoteBytes:
-    AsRef<[u8]>
-    + AsMut<[u8]>
-    + for<'a> From<&'a [u8]>
-    + for<'a> From<(&'a [u8], &'a [u8])>
-    + Clone
-    + Copy
-    + Send
-{
-    /// Constructs a new NoteBytesData from an empty slice of bytes.
-    fn new() -> Self;
+    fn from_slice_with_tag<const TAG_SIZE: usize>(
+        output: &[u8],
+        tag: [u8; TAG_SIZE],
+    ) -> Option<Self>;
 }
 
 impl<const N: usize> NoteBytes for NoteBytesData<N> {
-    /// Constructs a new NoteBytesData from an empty slice of bytes.
-    fn new() -> Self {
-        Self([0u8; N])
+    fn from_slice(bytes: &[u8]) -> Option<NoteBytesData<N>> {
+        let data = bytes.try_into().ok()?;
+        Some(NoteBytesData(data))
+    }
+
+    fn from_slice_with_tag<const TAG_SIZE: usize>(
+        output: &[u8],
+        tag: [u8; TAG_SIZE],
+    ) -> Option<NoteBytesData<N>> {
+        let expected_output_len = N.checked_sub(TAG_SIZE)?;
+
+        if output.len() != expected_output_len {
+            return None;
+        }
+
+        let mut data: [u8; N] = [0; N];
+
+        data[..expected_output_len].copy_from_slice(output);
+        data[expected_output_len..].copy_from_slice(&tag);
+
+        Some(NoteBytesData(data))
     }
 }

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -40,7 +40,7 @@ impl<const N: usize> NoteBytes for NoteBytesData<N> {
             return None;
         }
 
-        let mut data: [u8; N] = [0; N];
+        let mut data = [0u8; N];
 
         data[..expected_output_len].copy_from_slice(output);
         data[expected_output_len..].copy_from_slice(&tag);

--- a/src/note_bytes.rs
+++ b/src/note_bytes.rs
@@ -1,0 +1,66 @@
+/// Represents a fixed-size array of bytes for note components.
+#[derive(Clone, Copy, Debug)]
+pub struct NoteBytesData<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> AsRef<[u8]> for NoteBytesData<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const N: usize> AsMut<[u8]> for NoteBytesData<N> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl<const N: usize> From<&[u8]> for NoteBytesData<N> {
+    fn from(s: &[u8]) -> Self {
+        Self(s.try_into().unwrap())
+    }
+}
+
+impl<const N: usize> From<(&[u8], &[u8])> for NoteBytesData<N> {
+    fn from(s: (&[u8], &[u8])) -> Self {
+        let mut result: [u8; N] = [0; N];
+        result[..s.0.len()].copy_from_slice(s.0);
+        result[s.0.len()..].copy_from_slice(s.1);
+        NoteBytesData::from(result.as_ref())
+    }
+}
+
+/// Defines the ability to concatenate two byte slices.
+pub trait NoteByteConcat: for<'a> From<(&'a [u8], &'a [u8])> {}
+
+impl<const N: usize> NoteByteConcat for NoteBytesData<N> {}
+
+/// Defines the behavior for types that can provide read-only access to their internal byte array.
+pub trait NoteByteReader: AsRef<[u8]> + for<'a> From<&'a [u8]> + Clone + Copy {}
+
+impl<const N: usize> NoteByteReader for NoteBytesData<N> {}
+
+/// Defines the behavior for types that support both read and write access to their internal byte array.
+pub trait NoteByteWriter: NoteByteReader + AsMut<[u8]> {}
+
+impl<const N: usize> NoteByteWriter for NoteBytesData<N> {}
+
+/// Provides a unified interface for handling fixed-size byte arrays used in Orchard note encryption.
+pub trait NoteBytes:
+    AsRef<[u8]>
+    + AsMut<[u8]>
+    + for<'a> From<&'a [u8]>
+    + for<'a> From<(&'a [u8], &'a [u8])>
+    + Clone
+    + Copy
+    + Send
+{
+    /// Constructs a new NoteBytesData from an empty slice of bytes.
+    fn new() -> Self;
+}
+
+impl<const N: usize> NoteBytes for NoteBytesData<N> {
+    /// Constructs a new NoteBytesData from an empty slice of bytes.
+    fn new() -> Self {
+        Self([0u8; N])
+    }
+}


### PR DESCRIPTION
This PR implements the `parse_note_plaintext_bytes`, `parse_note_ciphertext_bytes`, and `parse_compact_note_plaintext_bytes` methods directly in the `Domain` trait of the `zcash_note_encryption` crate.

These `Domain` trait methods were previously implemented in the `orchard` and `sapling-crypto` crates, but, as it turns out, the implementation was the same for both crates and relied solely on the `NoteBytes` trait methods. Given this, we can simplify the code by moving these function implementations directly to the `Domain` trait in the `zcash_note_encryption` crate.
