### PR TITLE
Refactor enc_ciphertext to return reference instead of copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Changed
-- Breaking change: removed the constants `COMPACT_NOTE_SIZE`,
-  `NOTE_PLAINTEXT_SIZE`, and `ENC_CIPHERTEXT_SIZE` as they are no longer used
-  in the `zcash_note_encryption`, orchard`, or `sapling-crypto` crates.
+- **Breaking change:** removed the constants `COMPACT_NOTE_SIZE`,
+  `NOTE_PLAINTEXT_SIZE`, and `ENC_CIPHERTEXT_SIZE` as they are now
+  implementation spesific (located in `orchard` and `sapling-crypto` crates).
 - Generalized the note plaintext size to support variable sizes by adding the
   abstract types `NotePlaintextBytes`, `NoteCiphertextBytes`,
   `CompactNotePlaintextBytes`, and `CompactNoteCiphertextBytes` to the `Domain`
@@ -25,8 +25,7 @@ and this library adheres to Rust's notion of
   array.
 - Updated the `enc_ciphertext` method of the `ShieldedOutput` trait to return an
   `Option` of a reference instead of a copy.
-- Moved the specific constants into the `Domain` trait implementations.
-- Added new `note_bytes` module with helper trait and struct to deal with note
+- Added a new `note_bytes` module with helper trait and struct to deal with note
   bytes data with abstracted underlying array size.
   
 ## [0.4.0] - 2023-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Changed
+- Breaking change: removed the constants `COMPACT_NOTE_SIZE`,
+  `NOTE_PLAINTEXT_SIZE`, and `ENC_CIPHERTEXT_SIZE` as they are no longer used
+  in the `zcash_note_encryption`, orchard`, or `sapling-crypto` crates.
 - Generalized the note plaintext size to support variable sizes by adding the
   abstract types `NotePlaintextBytes`, `NoteCiphertextBytes`,
   `CompactNotePlaintextBytes`, and `CompactNoteCiphertextBytes` to the `Domain`
@@ -22,8 +25,7 @@ and this library adheres to Rust's notion of
   array.
 - Updated the `enc_ciphertext` method of the `ShieldedOutput` trait to return an
   `Option` of a reference instead of a copy.
-- Moved the specific constants into the `Domain` trait implementations, while
-  keeping the original constants for backward compatibility.
+- Moved the specific constants into the `Domain` trait implementations.
 - Added new `note_bytes` module with helper trait and struct to deal with note
   bytes data with abstracted underlying array size.
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,22 @@ and this library adheres to Rust's notion of
   abstract types `NotePlaintextBytes`, `NoteCiphertextBytes`,
   `CompactNotePlaintextBytes`, and `CompactNoteCiphertextBytes` to the `Domain`
   trait.
-- Moved the specific constants into the `Domain` trait implementations.
-
+- Removed the separate `NotePlaintextBytes` type definition (as it is now an
+  associated type).
+- Added new `parse_note_plaintext_bytes`, `parse_note_ciphertext_bytes`, and
+  `parse_compact_note_plaintext_bytes` methods to the `Domain` trait.
+- Updated the `note_plaintext_bytes` method of the `Domain` trait to return the
+  `NotePlaintextBytes` associated type.
+- Updated the `encrypt_note_plaintext` method of `NoteEncryption` to return the
+  `NoteCiphertextBytes` associated type of the `Domain` instead of the explicit
+  array.
+- Updated the `enc_ciphertext` method of the `ShieldedOutput` trait to return an
+  `Option` of a reference instead of a copy.
+- Moved the specific constants into the `Domain` trait implementations, while
+  keeping the original constants for backward compatibility.
+- Added new `note_bytes` module with helper trait and struct to deal with note
+  bytes data with abstracted underlying array size.
+  
 ## [0.4.0] - 2023-06-06
 ### Changed
 - The `esk` and `ephemeral_key` arguments have been removed from 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.56.1"
-components = [ "clippy", "rustfmt" ]
+components = ["clippy", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,19 +44,10 @@ pub mod note_bytes;
 
 use note_bytes::NoteBytes;
 
-/// The size of a compact note for Sapling and pre-ZSA Orchard.
-pub const COMPACT_NOTE_SIZE: usize = 1 + // version
-    11 + // diversifier
-    8  + // value
-    32; // rseed (or rcm prior to ZIP 212)
-/// The size of [`Domain::NotePlaintextBytes`] for Sapling and pre-ZSA Orchard.
-pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
 /// The size of [`OutPlaintextBytes`].
 pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
     32; // esk
 const AEAD_TAG_SIZE: usize = 16;
-/// The size of an encrypted note plaintext for Sapling and pre-ZSA Orchard.
-pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 /// The size of an encrypted outgoing plaintext.
 pub const OUT_CIPHERTEXT_SIZE: usize = OUT_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ pub trait ShieldedOutput<D: Domain> {
     fn cmstar_bytes(&self) -> D::ExtractedCommitmentBytes;
 
     /// Exposes the note ciphertext of the output. Returns `None` if the output is compact.
-    fn enc_ciphertext(&self) -> Option<D::NoteCiphertextBytes>;
+    fn enc_ciphertext(&self) -> Option<&D::NoteCiphertextBytes>;
 
     // FIXME: Should we return `Option<D::CompactNoteCiphertextBytes>` or
     // `&D::CompactNoteCiphertextBytes` instead? (complexity)?
@@ -383,8 +383,7 @@ pub trait ShieldedOutput<D: Domain> {
 
     //// Splits the AEAD tag from the ciphertext.
     fn split_ciphertext_at_tag(&self) -> Option<(D::NotePlaintextBytes, [u8; AEAD_TAG_SIZE])> {
-        let enc_ciphertext = self.enc_ciphertext()?;
-        let enc_ciphertext_bytes = enc_ciphertext.as_ref();
+        let enc_ciphertext_bytes = self.enc_ciphertext()?.as_ref();
 
         let (plaintext, tail) = enc_ciphertext_bytes
             .len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,27 +44,21 @@ pub mod note_bytes;
 
 use note_bytes::NoteBytes;
 
-/// The size of a compact note for Sapling and Orchard Vanilla.
+/// The size of a compact note for Sapling and pre-ZSA Orchard.
 pub const COMPACT_NOTE_SIZE: usize = 1 + // version
     11 + // diversifier
     8  + // value
     32; // rseed (or rcm prior to ZIP 212)
-/// The size of `NotePlaintextBytes` for Sapling and Orchard Vanilla.
+/// The size of [`NotePlaintextBytes`] for Sapling and pre-ZSA Orchard.
 pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
-
-/// The size of the memo.
-pub const MEMO_SIZE: usize = 512;
-/// The size of the authentication tag used for note encryption.
-pub const AEAD_TAG_SIZE: usize = 16;
-
 /// The size of [`OutPlaintextBytes`].
 pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
     32; // esk
+const AEAD_TAG_SIZE: usize = 16;
+/// The size of an encrypted note plaintext for Sapling and pre-ZSA Orchard.
+pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 /// The size of an encrypted outgoing plaintext.
 pub const OUT_CIPHERTEXT_SIZE: usize = OUT_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
-
-/// The size of an encrypted note plaintext for Sapling and Orchard Vanilla.
-pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 
 /// A symmetric key that can be used to recover a single Sapling or Orchard output.
 pub struct OutgoingCipherKey(pub [u8; 32]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub const COMPACT_NOTE_SIZE: usize = 1 + // version
     11 + // diversifier
     8  + // value
     32; // rseed (or rcm prior to ZIP 212)
-/// The size of [`NotePlaintextBytes`] for Sapling and pre-ZSA Orchard.
+/// The size of [`Domain::NotePlaintextBytes`] for Sapling and pre-ZSA Orchard.
 pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
 /// The size of [`OutPlaintextBytes`].
 pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,8 @@ pub trait Domain {
         plaintext: &Self::CompactNotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)>;
 
-    /// Splits the memo field from the given note plaintext.
+    /// Splits the given note plaintext into the compact part (containing the note) and
+    /// the memo field.
     ///
     /// # Compatibility
     ///


### PR DESCRIPTION
This PR updates the `ShieldedOutput` trait to return a reference from the `enc_ciphertext` method instead of a copy. This change was discussed and suggested in PR zcash/zcash_note_encryption#2 review.

Other minor changes:

- Fix the comment for `split_plaintext_at_memo`.
- Restore the original order of const definition to reduce PR diff.
- Remove extra spaces in `rust-toolchain.toml`.
- Remove unused constants `COMPACT_NOTE_SIZE`, `NOTE_PLAINTEXT_SIZE`, `ENC_CIPHERTEXT_SIZE`.
- Updated `CHANGELOG.md`.
