### PR TITLE
Restore `pub` visibility for `AEAD_TAG_SIZE` const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use note_bytes::NoteBytes;
 /// The size of [`OutPlaintextBytes`].
 pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
     32; // esk
-const AEAD_TAG_SIZE: usize = 16;
+pub const AEAD_TAG_SIZE: usize = 16;
 /// The size of an encrypted outgoing plaintext.
 pub const OUT_CIPHERTEXT_SIZE: usize = OUT_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 


### PR DESCRIPTION
Restore `pub` visibility for the `AEAD_TAG_SIZE` constant (it was mistakenly removed in the previous PR, but `AEAD_TAG_SIZE` needs to be `pub` as it's used not only in `zcash_note_encryption` but also in `orchard`).
